### PR TITLE
fix: check files using abs path

### DIFF
--- a/quests/copy/game.yml
+++ b/quests/copy/game.yml
@@ -164,7 +164,7 @@ stages:
       command:
         - ^cp hello.txt hello2.txt$
       files:
-        - path: hello2.txt
+        - path: /home/commander/hello2.txt
           type: file
     exceptions:
       - condition:
@@ -224,7 +224,7 @@ stages:
       command:
         - ^cp world.txt world2.txt$
       files:
-        - path: world2.txt
+        - path: /home/commander/world2.txt
           type: file
     exceptions:
       - condition:
@@ -292,9 +292,9 @@ stages:
       command:
         - ^cp
       files:
-        - path: notes2
+        - path: /home/commander/notes2
           type: directory
-        - path: notes2/note.txt
+        - path: /home/commander/notes2/note.txt
           type: file
     exceptions:
       - condition:

--- a/quests/create/game.yml
+++ b/quests/create/game.yml
@@ -44,12 +44,12 @@ stages:
       - ls
     condition:
       files:
-        - path: hello.txt
+        - path: /home/commander/hello.txt
           type: file
     exceptions:
       - condition:
           files:
-            - path: hello$
+            - path: /home/commander/hello
               type: file
         responses:
           - type: narrative
@@ -107,12 +107,12 @@ stages:
       - ls-touch
     condition:
       files:
-        - path: world.txt
+        - path: /home/commander/world.txt
           type: file
     exceptions:
       - condition:
           files:
-            - path: world$
+            - path: /home/commander/world
               type: file
         responses:
           - type: narrative
@@ -154,7 +154,7 @@ stages:
       - ls-2
     condition:
       files:
-        - path: notes
+        - path: /home/commander/notes
           type: folder
     responses:
       - type: narrative
@@ -203,7 +203,7 @@ stages:
       - cd-notes
     condition:
       files:
-        - path: notes/note.txt
+        - path: /home/commander/notes/note.txt
           type: file
     responses:
       - type: narrative

--- a/quests/move/game.yml
+++ b/quests/move/game.yml
@@ -49,9 +49,9 @@ stages:
       command:
         - ^mv hello.txt notes$
       files:
-        - path: notes/hello.txt
+        - path: /home/commander/notes/hello.txt
           type: file
-        - path: hello.txt
+        - path: /home/commander/hello.txt
           exists: false
     responses:
       - type: narrative
@@ -106,9 +106,9 @@ stages:
       command:
         - ^mv
       files:
-        - path: wow.txt
+        - path: /home/commander/wow.txt
           type: file
-        - path: world.txt
+        - path: /home/commander/world.txt
           exists: false
     responses:
       - type: narrative
@@ -148,9 +148,9 @@ stages:
       command:
         - ^mv
       files:
-        - path: docs
+        - path: /home/commander/docs
           type: directory
-        - path: notes
+        - path: /home/commander/notes
           exists: false
     responses:
       - type: narrative
@@ -187,9 +187,9 @@ stages:
       command:
         - ^mv
       files:
-        - path: hi.txt
+        - path: /home/commander/hi.txt
           type: file
-        - path: docs/hello.txt
+        - path: /home/commander/docs/hello.txt
           exists: false
     exceptions:
       - condition:

--- a/quests/remove/game.yml
+++ b/quests/remove/game.yml
@@ -44,7 +44,7 @@ stages:
       command:
         - ^rm\s
       files:
-        - path: hello.txt
+        - path: /home/commander/hello.txt
           exists: false
     responses:
       - content: |
@@ -58,7 +58,7 @@ stages:
       command:
         - ^ls$
       files:
-        - path: hello.txt
+        - path: /home/commander/hello.txt
           exists: false
     responses:
       - content: |
@@ -78,9 +78,9 @@ stages:
       command:
         - ^rm
       files:
-        - path: world.txt
+        - path: /home/commander/world.txt
           exists: false
-        - path: wow.txt
+        - path: /home/commander/wow.txt
           exists: false
     responses:
       - content: |
@@ -111,7 +111,7 @@ stages:
       command:
         - ^rmdir empty$
       files:
-        - path: empty
+        - path: /home/commander/empty
           exists: false
     responses:
       - content: |
@@ -139,7 +139,7 @@ stages:
       command:
         - ^rmdir notes$
       files:
-        - path: notes
+        - path: /home/commander/notes
           type: folder
           exists: true
     responses:
@@ -161,10 +161,10 @@ stages:
       command:
         - ^rm
       files:
-        - path: notes
+        - path: /home/commander/notes
           type: folder
           exists: true
-        - path: notes/note.txt
+        - path: /home/commander/notes/note.txt
           exists: false
     exceptions:
       - condition:
@@ -203,7 +203,7 @@ stages:
     task: 使用 `rmdir` 刪除 `notes` 資料夾
     condition:
       files:
-        - path: notes
+        - path: /home/commander/notes
           exists: false
     responses:
       - content: |
@@ -238,7 +238,7 @@ stages:
       command:
         - ^rm -r trash$
       files:
-        - path: trash
+        - path: /home/commander/trash
           exists: false
     responses:
       - content: |


### PR DESCRIPTION
the docker user is changed from commander to root due to #168 pr.
Use absolute path instead of relative path to prevent false detection.